### PR TITLE
GravatarId cant be empty

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,7 +1,8 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in('src');
+    ->in('src')
+    ->in('tests');
 
 return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)

--- a/src/GravatarId.php
+++ b/src/GravatarId.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DevboardLib\Generix;
 
+use DomainException;
+
 /**
  * @see \spec\DevboardLib\Generix\GravatarIdSpec
  * @see \Tests\DevboardLib\Generix\GravatarIdTest
@@ -15,6 +17,9 @@ class GravatarId
 
     public function __construct(string $id)
     {
+        if (true === empty($id)) {
+            throw new DomainException('GravatarId cant be empty');
+        }
         $this->id = $id;
     }
 

--- a/tests/GravatarIdTest.php
+++ b/tests/GravatarIdTest.php
@@ -49,4 +49,13 @@ class GravatarIdTest extends TestCase
     {
         self::assertEquals($this->sut, $this->sut->deserialize($this->id));
     }
+
+    /**
+     * @expectedException \DomainException
+     * @expectedExceptionMessage GravatarId cant be empty
+     */
+    public function testCantBeEmpty()
+    {
+        new GravatarId('');
+    }
 }


### PR DESCRIPTION
It's going to be easier to fix all of the other code by throwing an exception if we push an empty value in here