### PR TITLE
Add Serializable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG
 
-
+Next release:
+ - Adding Serializable interface (#35)
+ - Using Serializable in existing interfaces (#35)
 
 Version 1.0: Up to this point, there is no documentation on given code but we do hope to fix that soon :)
 

--- a/src/Command/QueueableCommand.php
+++ b/src/Command/QueueableCommand.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace DevboardLib\Generix\Command;
 
-interface QueueableCommand extends Command
+use DevboardLib\Generix\Serializable;
+
+interface QueueableCommand extends Command, Serializable
 {
-    public function serialize(): array;
-
-    public static function deserialize(array $data);
-
     public function getQueueName(): string;
 
     public function getQueuePriority(): int;

--- a/src/QueryRequest.php
+++ b/src/QueryRequest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace DevboardLib\Generix;
 
-interface QueryRequest
+interface QueryRequest extends Serializable
 {
-    public function serialize(): array;
-
-    public static function deserialize(array $data);
 }

--- a/src/QueryResult.php
+++ b/src/QueryResult.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace DevboardLib\Generix;
 
-interface QueryResult
+interface QueryResult extends Serializable
 {
-    public function serialize(): array;
-
-    public static function deserialize(array $data);
 }

--- a/src/Serializable.php
+++ b/src/Serializable.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DevboardLib\Generix;
+
+interface Serializable
+{
+    public function serialize(): array;
+
+    public static function deserialize(array $data);
+}


### PR DESCRIPTION
In order to know object is serializable, lets add our own implementation of Serializable interface. As well, we will use it in existing interfaces defined to keep things more easily maintained.

Closes #35