### PR TITLE
Add `->asString()` and deprecate `__toString()`

### DIFF
--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -34,6 +34,14 @@ class EmailAddress
         return $this->valid;
     }
 
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/RequestId.php
+++ b/src/RequestId.php
@@ -30,6 +30,14 @@ class RequestId
         return $this->id;
     }
 
+    public function asString(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString()
     {
         return $this->id;


### PR DESCRIPTION
We should really not be using magic `__toString()`